### PR TITLE
Update replace_define function to avoid dict mutation during iteration

### DIFF
--- a/MarlinSV06Plus/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/MarlinSV06Plus/buildroot/share/PlatformIO/scripts/marlin.py
@@ -19,7 +19,8 @@ def copytree(src, dst, symlinks=False, ignore=None):
             shutil.copy2(s, d)
 
 def replace_define(field, value):
-	for define in env['CPPDEFINES']:
+	envdefs = env['CPPDEFINES'].copy()
+	for define in envdefs:
 		if define[0] == field:
 			env['CPPDEFINES'].remove(define)
 	env['CPPDEFINES'].append((field, value))


### PR DESCRIPTION
https://github.com/Sovol3d/SV06-PLUS/pull/3

https://community.platformio.org/t/marlin-runtimeerror-deque-mutated-during-iteration/34661/5